### PR TITLE
should mark UTF-8 on the non-ASCII colnames

### DIFF
--- a/src/DbDataFrame.cpp
+++ b/src/DbDataFrame.cpp
@@ -54,7 +54,9 @@ List DbDataFrame::get_data(std::vector<DATA_TYPE>& types_) {
   boost::for_each(data, names, boost::bind(&DbColumn::warn_type_conflicts, _1, _2));
 
   List out(data.begin(), data.end());
-  out.attr("names") = names;
+  StringVector names_utf8 = wrap(names);
+  for (int i = 0; i < names_utf8.size(); ++i) names_utf8[i] = Rf_mkCharCE(names_utf8[i], CE_UTF8);
+  out.attr("names") = names_utf8;
   out.attr("class") = "data.frame";
   out.attr("row.names") = IntegerVector::create(NA_INTEGER, -i);
   return out;

--- a/tests/testthat/test-dbSendQuery.R
+++ b/tests/testthat/test-dbSendQuery.R
@@ -144,3 +144,13 @@ test_that("NA matches NULL", {
 
   expect_equal(got$id, "x")
 })
+
+test_that("mark UTF-8 encoding on non-ASCII colnames", {
+  con <- dbConnect(SQLite())
+  on.exit(dbDisconnect(con))
+  tbl <- data.frame("中文" = "a")
+  dbWriteTable(con, name = "test", value = tbl)
+  got <- dbListFields(con, "test")
+  expect_equal(Encoding(got), "UTF-8")
+  expect_equal(got, "中文")
+})


### PR DESCRIPTION
Otherwise, it leads to garbage colnames on Windows. This PR should fix the issue.

### Example

``` r
conn <- DBI::dbConnect(RSQLite::SQLite())
tbl <- data.frame("中文" = 'a')
DBI::dbWriteTable(conn, name = 'test', value = tbl)
DBI::dbListFields(conn, 'test')
#> [1] "涓枃"
```

<sup>Created on 2018-12-30 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
<details><summary>Session info</summary>

``` r
devtools::session_info()
#> Session info -------------------------------------------------------------
#>  setting  value                                              
#>  version  R version 3.5.1 (2018-07-02)                       
#>  system   x86_64, mingw32                                    
#>  ui       RTerm                                              
#>  language (EN)                                               
#>  collate  Chinese (Simplified)_People's Republic of China.936
#>  tz       Asia/Taipei                                        
#>  date     2018-12-30
#> Packages -----------------------------------------------------------------
#>  package   * version date       source        
#>  backports   1.1.2   2017-12-13 CRAN (R 3.5.0)
#>  base      * 3.5.1   2018-07-02 local         
#>  bit         1.1-14  2018-05-29 CRAN (R 3.5.2)
#>  bit64       0.9-7   2017-05-08 CRAN (R 3.5.2)
#>  blob        1.1.1   2018-03-25 CRAN (R 3.5.2)
#>  compiler    3.5.1   2018-07-02 local         
#>  datasets  * 3.5.1   2018-07-02 local         
#>  DBI         1.0.0   2018-05-02 CRAN (R 3.5.2)
#>  devtools    1.13.6  2018-06-27 CRAN (R 3.5.1)
#>  digest      0.6.17  2018-09-12 CRAN (R 3.5.1)
#>  evaluate    0.11    2018-07-17 CRAN (R 3.5.1)
#>  graphics  * 3.5.1   2018-07-02 local         
#>  grDevices * 3.5.1   2018-07-02 local         
#>  htmltools   0.3.6   2017-04-28 CRAN (R 3.5.1)
#>  knitr       1.20    2018-02-20 CRAN (R 3.5.1)
#>  magrittr    1.5     2014-11-22 CRAN (R 3.5.1)
#>  memoise     1.1.0   2017-04-21 CRAN (R 3.5.1)
#>  methods   * 3.5.1   2018-07-02 local         
#>  pkgconfig   2.0.2   2018-08-16 CRAN (R 3.5.2)
#>  Rcpp        1.0.0   2018-11-07 CRAN (R 3.5.1)
#>  rmarkdown   1.10    2018-06-11 CRAN (R 3.5.1)
#>  rprojroot   1.3-2   2018-01-03 CRAN (R 3.5.1)
#>  RSQLite     2.1.1   2018-05-06 CRAN (R 3.5.2)
#>  stats     * 3.5.1   2018-07-02 local         
#>  stringi     1.1.7   2018-03-12 CRAN (R 3.5.0)
#>  stringr     1.3.1   2018-05-10 CRAN (R 3.5.1)
#>  tools       3.5.1   2018-07-02 local         
#>  utils     * 3.5.1   2018-07-02 local         
#>  withr       2.1.2   2018-03-15 CRAN (R 3.5.1)
#>  yaml        2.2.0   2018-07-25 CRAN (R 3.5.1)
```

</details>