### PR TITLE
allow dbWriteTable method for text file to work within open transaction

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -193,8 +193,8 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "character"),
 
     row.names <- compatRowNames(row.names)
 
-    dbBegin(conn)
-    on.exit(dbRollback(conn))
+    dbBegin(conn, name='dbWriteTable')
+    on.exit(dbRollback(conn, name='dbWriteTable'))
 
     found <- dbExistsTable(conn, name)
     if (found && !overwrite && !append) {
@@ -223,7 +223,7 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "character"),
     skip <- skip + as.integer(header)
     connection_import_file(conn@ptr, name, value, sep, eol, skip)
 
-    dbCommit(conn)
+    dbCommit(conn, name='dbWriteTable')
     on.exit(NULL)
     invisible(TRUE)
   }

--- a/tests/testthat/test-dbWriteTable.R
+++ b/tests/testthat/test-dbWriteTable.R
@@ -187,6 +187,26 @@ test_that("temporary works", {
   expect_false(dbExistsTable(con2, "tmp"))
 })
 
+test_that("works within transaction", {
+  con <- dbConnect(SQLite())
+  on.exit(dbDisconnect(con))
+
+  df <- data.frame(
+    a = c(1:3, NA),
+    b = c("x", "y", "z", "E"),
+    stringsAsFactors = FALSE
+  )
+
+  csv_file <- tempfile(fileext='.csv')
+  write.csv(df, file=csv_file, row.names=FALSE, eol='\n')
+  dbWithTransaction(con, {
+    dbWriteTable(con, 'tbl', csv_file, eol='\n', overwrite=TRUE)
+    expect_true(dbExistsTable(con, 'tbl'))
+    dbBreak()
+  })
+  expect_false(dbExistsTable(con, 'tbl'))
+})
+
 
 # Append ------------------------------------------------------------------
 


### PR DESCRIPTION
`dbWriteTable` previously failed when run within a transaction passing a text file rather than a dataframe. (signature `conn="SQLiteConnection", name="character", value="character"`)

MRE:

```
library(RSQLite) # current dev version or below
tmp <- tempfile()
db <- dbConnect(SQLite(), dbname=tmp)

tmp_csv <- tempfile()
write.csv(mtcars, tmp_csv)

# fails 
dbWithTransaction(db, {
    dbWriteTable(db, 'tbl_mtcars', tmp_csv, overwrite=TRUE)
})
dbDisconnect(db)
```
returns error message
```
Error in result_create(conn@ptr, statement) : 
  cannot start a transaction within a transaction
```

This PR uses the  approach in `dbWriteTable` signature for 
`conn="SQLiteConnection", name="character", value="data.frame"` to avoid this error. 