### PR TITLE
Only export relevant symbols to shared library.

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -12,6 +12,9 @@ PKG_CPPFLAGS=-I. \
              -DRCPP_USING_UTF8_ERROR_STRING \
              -DBOOST_NO_AUTO_PTR
 
+PKG_CXXFLAGS=$(CXX_VISIBILITY)
+PKG_CFLAGS=$(C_VISIBILITY)
+
 PKG_LIBS = vendor/sqlite3/sqlite3.o
 
 .PHONY: all

--- a/src/extension-functions.c
+++ b/src/extension-functions.c
@@ -1,3 +1,4 @@
 #define SQLITE_CORE
 #define sqlite3_extension_init sqlite3_math_init
+#include <R_ext/Visibility.h>
 #include "vendor/sqlite3/extension-functions.c"

--- a/src/vendor/sqlite3/extension-functions.c
+++ b/src/vendor/sqlite3/extension-functions.c
@@ -1832,7 +1832,7 @@ int RegisterExtensionFunctions(sqlite3 *db){
 }
 
 #ifdef COMPILE_SQLITE_EXTENSIONS_AS_LOADABLE_MODULE
-int sqlite3_extension_init(
+attribute_visible int sqlite3_extension_init(
     sqlite3 *db, char **pzErrMsg, const sqlite3_api_routines *pApi){
   SQLITE_EXTENSION_INIT2(pApi);
   RegisterExtensionFunctions(db);

--- a/src/vendor/sqlite3/regexp.c
+++ b/src/vendor/sqlite3/regexp.c
@@ -58,6 +58,7 @@
 */
 #include <string.h>
 #include <stdlib.h>
+#include <R_ext/Visibility.h>
 #include "sqlite3ext.h"
 SQLITE_EXTENSION_INIT1
 
@@ -747,7 +748,7 @@ static void re_sql_func(
 #ifdef _WIN32
 __declspec(dllexport)
 #endif
-int sqlite3_regexp_init(
+attribute_visible int sqlite3_regexp_init(
   sqlite3 *db, 
   char **pzErrMsg, 
   const sqlite3_api_routines *pApi


### PR DESCRIPTION
Hi, 

I have problems using RPostgres and RSQLite from the same R-process.

I get stacktraces such as these:

```
 *** caught segfault ***
address 0x1000000010, cause 'memory not mapped'

Traceback:
 1: result_release(res@ptr)
 2: dbClearResult(rs)
 3: dbClearResult(rs)
 4: dbExecute(con, "SET TIMEZONE='UTC'")
 5: dbExecute(con, "SET TIMEZONE='UTC'")
 6: .local(drv, ...)
 7: DBI::dbConnect(RPostgres::Postgres(), dbname = "kingfisher")
 8: DBI::dbConnect(RPostgres::Postgres(), dbname = "kingfisher")
 9: eval(expr)
10: eval(expr)
11: create_connection(production = production)
12: load_list_of_tables("ensembl", tables, production = production)
An irrecoverable exception occurred. R is aborting now ...
bin/load_ensembl.sh: line 7: 36907 Segmentation fault      (core dumped) Rscript R/load_ensembl.R
```

After wading through the code with gdb it appears that RSQLite's result_release collides with RPostgres' result_release in their respective shared libraries. The best way to fix that is probably to only export symbols from the shared library which will be needed by R.

So I suggest changing default symbol visibility to hidden, so the two libraries can coexist peacefully.

See here for more information:
https://github.com/RcppCore/Rcpp/pull/720

