### PR TITLE
Minor fix so old function matches docs

### DIFF
--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -47,7 +47,7 @@ setGeneric("dbBeginTransaction", function(conn, ...) {
 #' @keywords internal
 #' @aliases dbBuildTableDefinition
 #' @export
-sqliteBuildTableDefinition <- function(con, name, value, field.types = NULL,
+sqliteBuildTableDefinition <- function(conn, name, value, field.types = NULL,
                                        row.names = pkgconfig::get_config("RSQLite::row.names.query", FALSE)) {
 
   warning_once("RSQLite::sqliteBuildTableDefinition() is deprecated, please switch to DBI::sqlCreateTable().")


### PR DESCRIPTION
con in function, conn in docs and other functions

this is v low priority, but sending a fix now while I am looking in here / updating another package. I believe since con is a prefix of conn, partial matching will prevent any breakage in the event someone is passing by con by name.