### PR TITLE
dbWriteTable() and dbAppendTable() use transactions with unique savepoint IDs

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -88,8 +88,9 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "data.frame"),
 
     name <- check_quoted_identifier(name)
 
-    dbBegin(conn, name = "dbWriteTable")
-    on.exit(dbRollback(conn, name = "dbWriteTable"))
+    savepoint_id <- get_savepoint_id("dbWriteTable")
+    dbBegin(conn, name = savepoint_id)
+    on.exit(dbRollback(conn, name = savepoint_id))
 
     found <- dbExistsTable(conn, name)
     if (found && !overwrite && !append) {
@@ -193,8 +194,9 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "character"),
 
     row.names <- compatRowNames(row.names)
 
-    dbBegin(conn, name = "dbWriteTable")
-    on.exit(dbRollback(conn, name = "dbWriteTable"))
+    savepoint_id <- get_savepoint_id("dbWriteTable")
+    dbBegin(conn, name = savepoint_id)
+    on.exit(dbRollback(conn, name = savepoint_id))
 
     found <- dbExistsTable(conn, name)
     if (found && !overwrite && !append) {
@@ -233,8 +235,9 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "character"),
 #' @export
 setMethod("dbAppendTable", "SQLiteConnection", function(conn, name, value, ...,
                                                         row.names = NULL) {
-  dbBegin(conn, name = "dbAppendTable")
-  on.exit(dbRollback(conn, name = "dbAppendTable"))
+  savepoint_id <- get_savepoint_id("dbAppendTable")
+  dbBegin(conn, name = savepoint_id)
+  on.exit(dbRollback(conn, name = savepoint_id))
 
   out <- callNextMethod()
 

--- a/R/table.R
+++ b/R/table.R
@@ -125,7 +125,7 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "data.frame"),
       )
     }
 
-    dbCommit(conn, name = "dbWriteTable")
+    dbCommit(conn, name = savepoint_id)
     on.exit(NULL)
     invisible(TRUE)
   }
@@ -225,7 +225,7 @@ setMethod("dbWriteTable", c("SQLiteConnection", "character", "character"),
     skip <- skip + as.integer(header)
     connection_import_file(conn@ptr, name, value, sep, eol, skip)
 
-    dbCommit(conn, name = "dbWriteTable")
+    dbCommit(conn, name = savepoint_id)
     on.exit(NULL)
     invisible(TRUE)
   }
@@ -242,7 +242,7 @@ setMethod("dbAppendTable", "SQLiteConnection", function(conn, name, value, ...,
   out <- callNextMethod()
 
   on.exit(NULL)
-  dbCommit(conn, name = "dbAppendTable")
+  dbCommit(conn, name = savepoint_id)
 
   out
 })

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -110,5 +110,5 @@ compat_name <- function(name, .name) {
 
 get_savepoint_id <- function(name) {
   random_string <- paste(sample(letters, 10, replace = TRUE), collapse = "")
-  paste0(name, "-", Sys.getpid(), "-", random_string)
+  paste0(name, "_", Sys.getpid(), "_", random_string)
 }

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -107,3 +107,8 @@ compat_name <- function(name, .name) {
     name
   }
 }
+
+get_savepoint_id <- function(name) {
+  random_string <- paste(sample(letters, 10, replace = TRUE), collapse = "")
+  paste0(name, "-", Sys.getpid(), "-", random_string)
+}


### PR DESCRIPTION
to avoid lost rows with parallel writes.

Closes #280.