### PR TITLE
Loading extensions works when RSQLite is installed in a path with non-ASCII characters

### DIFF
--- a/R/extensions.R
+++ b/R/extensions.R
@@ -30,8 +30,12 @@ initExtension <- function(db) {
       call. = FALSE)
   }
 
-  lib_path <- getLoadedDLLs()[["RSQLite"]][["path"]]
-  extension_load(db@ptr, lib_path, "sqlite3_math_init")
+  extension_load(db@ptr, get_lib_path(), "sqlite3_math_init")
 
   invisible(TRUE)
+}
+
+get_lib_path <- function() {
+  lib_path <- getLoadedDLLs()[["RSQLite"]][["path"]]
+  enc2utf8(lib_path)
 }

--- a/R/regularExpressions.R
+++ b/R/regularExpressions.R
@@ -27,8 +27,7 @@ initRegExp <- function(db) {
          call. = FALSE)
   }
 
-  lib_path <- getLoadedDLLs()[["RSQLite"]][["path"]]
-  extension_load(db@ptr, lib_path, "sqlite3_regexp_init")
+  extension_load(db@ptr, get_lib_path(), "sqlite3_regexp_init")
 
   # always return TRUE after loading
   invisible(TRUE)


### PR DESCRIPTION
Closes #310.