### PR TITLE
Abort explicitly if busy handler fails

### DIFF
--- a/R/SQLiteConnection.R
+++ b/R/SQLiteConnection.R
@@ -215,10 +215,9 @@ setMethod("dbGetInfo", "SQLiteConnection", function(dbObj, ...) {
 #'
 #' Handler callbacks are useful for debugging concurrent behavior, or to
 #' implement a more sophisticated busy algorithm. The latter is currently
-#' considered experimental in RSQLite, especially with respect to errors and
-#' interruption in the handler function. According to our current tests,
-#' after the handler function fails or is interrupted, the database
-#' connection is still functional, but this might not be always the case.
+#' considered experimental in RSQLite. If the callback function fails, then
+#' RSQLite will print a warning, and the transaction is aborted with a
+#' "database is locked" error.
 #'
 #' Note that every database connection has its own busy timeout or handler
 #' function.

--- a/man/sqliteSetBusyHandler.Rd
+++ b/man/sqliteSetBusyHandler.Rd
@@ -57,10 +57,9 @@ database and the cycle repeats.
 
 Handler callbacks are useful for debugging concurrent behavior, or to
 implement a more sophisticated busy algorithm. The latter is currently
-considered experimental in RSQLite, especially with respect to errors and
-interruption in the handler function. According to our current tests,
-after the handler function fails or is interrupted, the database
-connection is still functional, but this might not be always the case.
+considered experimental in RSQLite. If the callback function fails, then
+RSQLite will print a warning, and the transaction is aborted with a
+"database is locked" error.
 
 Note that every database connection has its own busy timeout or handler
 function.

--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -109,10 +109,20 @@ void DbConnection::release_callback_data() {
 
 int DbConnection::busy_callback_helper(void *data, int num) {
   SEXP r_callback = reinterpret_cast <SEXP> (data);
+
   try {
     Function rfun = r_callback;
     IntegerVector ret = rfun(num);
     return as<int>(ret);
+
+  } catch(eval_error &e) {
+    Rcpp::warning("Busy callback failed, aborting transaction: %s", e.what());
+    return 0;
+
+  } catch(Rcpp::internal::InterruptedException &e) {
+    // Not warning on explicit interrupt
+    return 0;
+
   } catch(...) {
     Rcpp::warning("Busy callback failed, aborting transaction");
     return 0;

--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -109,7 +109,12 @@ void DbConnection::release_callback_data() {
 
 int DbConnection::busy_callback_helper(void *data, int num) {
   SEXP r_callback = reinterpret_cast <SEXP> (data);
-  Function rfun = r_callback;
-  IntegerVector ret = rfun(num);
-  return as<int>(ret);
+  try {
+    Function rfun = r_callback;
+    IntegerVector ret = rfun(num);
+    return as<int>(ret);
+  } catch(...) {
+    Rcpp::warning("Busy callback failed, aborting transaction");
+    return 0;
+  }
 }

--- a/tests/testthat/test-dbConnect.R
+++ b/tests/testthat/test-dbConnect.R
@@ -123,7 +123,10 @@ test_that("error in busy handler", {
   sqliteSetBusyHandler(con2, cb)
 
   dbExecute(con1, "BEGIN IMMEDIATE")
-  expect_error(dbExecute(con2, "BEGIN IMMEDIATE"), "oops")
+  expect_error(
+    expect_warning(dbExecute(con2, "BEGIN IMMEDIATE"), "aborting"),
+    "database is locked"
+  )
 
   # con1 is still fine of course
   dbWriteTable(con1, "mtcars", mtcars)

--- a/tests/testthat/test-dbConnect.R
+++ b/tests/testthat/test-dbConnect.R
@@ -124,7 +124,10 @@ test_that("error in busy handler", {
 
   dbExecute(con1, "BEGIN IMMEDIATE")
   expect_error(
-    expect_warning(dbExecute(con2, "BEGIN IMMEDIATE"), "aborting"),
+    expect_warning(
+      dbExecute(con2, "BEGIN IMMEDIATE"),
+      "Busy callback failed, aborting.*oops"
+    ),
     "database is locked"
   )
 


### PR DESCRIPTION
On Solaris Rcpp or sqlite crashes if the busy handler
does not return, so now we catch errors in the busy
handler, and throw a warning and abort the transaction.

I tested it on Solaris.

Closes #348.