### PR TITLE
Add extended type support to dbWriteTable

### DIFF
--- a/R/SQLiteDriver.R
+++ b/R/SQLiteDriver.R
@@ -21,7 +21,7 @@ setClass("SQLiteDriver",
 
 #' @rdname SQLiteDriver-class
 #' @export
-setMethod("dbDataType", "SQLiteDriver", function(dbObj, obj, ...) {
+setMethod("dbDataType", "SQLiteDriver", function(dbObj, obj, extended_types = FALSE, ...) {
   if (is.factor(obj)) {
     return("TEXT")
   }
@@ -30,6 +30,15 @@ setMethod("dbDataType", "SQLiteDriver", function(dbObj, obj, ...) {
   }
   if (is.integer64(obj)) {
     return("INTEGER")
+  }
+  if (extended_types && methods::is(obj, "Date")) {
+    return("DATE")
+  }
+  if (extended_types && methods::is(obj, "POSIXct")) {
+    return("TIMESTAMP")
+  }
+  if (extended_types && methods::is(obj, "hms")) {
+    return("TIME")
   }
 
   switch(typeof(obj),

--- a/R/SQLiteDriver.R
+++ b/R/SQLiteDriver.R
@@ -21,7 +21,7 @@ setClass("SQLiteDriver",
 
 #' @rdname SQLiteDriver-class
 #' @export
-setMethod("dbDataType", "SQLiteDriver", function(dbObj, obj, extended_types = FALSE, ...) {
+setMethod("dbDataType", "SQLiteDriver", function(dbObj, obj, ..., extended_types = FALSE) {
   if (is.factor(obj)) {
     return("TEXT")
   }

--- a/R/table.R
+++ b/R/table.R
@@ -426,5 +426,5 @@ sqliteListTablesQuery <- function(conn, schema = NULL, name = NULL) {
 #' @rdname SQLiteConnection-class
 #' @export
 setMethod("dbDataType", "SQLiteConnection", function(dbObj, obj, ...) {
-  dbDataType(SQLite(), obj, ...)
+  dbDataType(SQLite(), obj, extended_types = dbObj@extended_types, ...)
 })

--- a/man/SQLite.Rd
+++ b/man/SQLite.Rd
@@ -138,9 +138,9 @@ dbGetQuery(con, "SELECT * FROM USArrests")
 
 # Or do it in batches
 rs <- dbSendQuery(con, "SELECT * FROM USArrests")
-d1 <- dbFetch(rs, n = 10)      # extract data in chunks of 10 rows
+d1 <- dbFetch(rs, n = 10) # extract data in chunks of 10 rows
 dbHasCompleted(rs)
-d2 <- dbFetch(rs, n = -1)      # extract all remaining data
+d2 <- dbFetch(rs, n = -1) # extract all remaining data
 dbHasCompleted(rs)
 dbClearResult(rs)
 

--- a/man/SQLiteDriver-class.Rd
+++ b/man/SQLiteDriver-class.Rd
@@ -9,7 +9,7 @@
 \alias{dbGetInfo,SQLiteDriver-method}
 \title{Class SQLiteDriver (and methods)}
 \usage{
-\S4method{dbDataType}{SQLiteDriver}(dbObj, obj, ...)
+\S4method{dbDataType}{SQLiteDriver}(dbObj, obj, extended_types = FALSE, ...)
 
 \S4method{dbIsValid}{SQLiteDriver}(dbObj, ...)
 

--- a/tests/testthat/test-extendedTypes.R
+++ b/tests/testthat/test-extendedTypes.R
@@ -126,3 +126,21 @@ test_that("Blob as time", {
   expect_warning(resdf <- dbGetQuery(con, "SELECT * from t1"), "Cannot convert blob, NA is returned.")
   expect_that(resdf[[1]], equals(structure(NA_real_, units = "secs", class = c("hms", "difftime"))))
 })
+
+
+test_that("roundtrip extended_types with dbWriteTable", {
+  con <- dbConnect(SQLite(), extended_types = TRUE)
+  on.exit(dbDisconnect(con), add = TRUE)
+
+  dates_times <- data.frame(some_date = as.Date(c("2000-01-01", "2000-02-03")),
+                            some_datetime = .POSIXct(1:2, tz = "UTC"),
+                            some_time = hms::hms(1:2))
+
+  dbWriteTable(con, "dates_times", dates_times)
+
+  to_match <- dbReadTable(con, "dates_times")
+
+  expect_identical(lapply(to_match, class),
+                   lapply(dates_times, class))
+
+})


### PR DESCRIPTION
This PR modifies the dbDataType method to recognize date, time, and datetime types when the extended_types argument is TRUE. #351 