### PR TITLE
SQLite: build with SQLITE_USE_URI=1

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -8,6 +8,7 @@ PKG_CPPFLAGS=-I. -Ivendor \
              -DSQLITE_ENABLE_JSON1 \
              -DSQLITE_ENABLE_STAT4 \
              -DSQLITE_SOUNDEX \
+             -DSQLITE_USE_URI=1 \
              -DRCPP_DEFAULT_INCLUDE_CALL=false \
              -DRCPP_USING_UTF8_ERROR_STRING \
              -DBOOST_NO_AUTO_PTR \


### PR DESCRIPTION
We have seen some problems attaching to in-memory databases from RSQLite that have been created from within C code, resulting in files being created on the filesystem such as `tests/testthat/file:name?mode=memory&vfs=some-stub`, due to RSQLite not understanding that these are URIs.

We have managed to resolve these problems with the attached patch, which essentially enables URI support at compile-time.

It may be relevant to reviewers to note that the SQLite developers [state](https://sqlite.org/uri.html) that it is safe for most applications to enable URI processing:

> Since SQLite always interprets any filename that does not begin with "file:" as an ordinary filename regardless of the URI setting, and because it is very unusual to have an actual file begin with "file:", it is safe for most applications to enable URI processing even if URI filenames are not currently being used.

CC: @jrandall