### PR TITLE
prefer .empty() to .size()==0

### DIFF
--- a/src/DbColumn.cpp
+++ b/src/DbColumn.cpp
@@ -50,7 +50,7 @@ void DbColumn::warn_type_conflicts(const String& name) const {
   my_data_types_seen.erase(DT_BOOL);
   my_data_types_seen.erase(dt);
 
-  if (my_data_types_seen.size() == 0) return;
+  if (my_data_types_seen.empty()) return;
 
   String name_utf8 = name;
   name_utf8.set_encoding(CE_UTF8);

--- a/src/DbConnection.cpp
+++ b/src/DbConnection.cpp
@@ -8,7 +8,7 @@ DbConnection::DbConnection(const std::string& path, const bool allow_ext, const 
     busy_callback_(NULL) {
 
   // Get the underlying database connection
-  int rc = sqlite3_open_v2(path.c_str(), &pConn_, flags, vfs.size() ? vfs.c_str() : NULL);
+  int rc = sqlite3_open_v2(path.c_str(), &pConn_, flags, vfs.empty() ? NULL : vfs.c_str());
   if (rc != SQLITE_OK) {
     stop("Could not connect to database:\n%s", getException());
   }


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html