### PR TITLE
docs: Reword warning message for misuse of  `dbGetQuery()`/`dbSendQuery()`/`dbFetch()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,7 @@ Suggests:
     callr,
     cli,
     DBItest (>= 1.8.0),
+    decor,
     gert,
     gh,
     hms,

--- a/src/SqliteResultImpl.cpp
+++ b/src/SqliteResultImpl.cpp
@@ -312,7 +312,7 @@ cpp11::list SqliteResultImpl::fetch_rows(const int n_max, int& n) {
   SqliteDataFrame data(stmt, cache.names_, n_max, types_, with_alt_types_);
 
   if (complete_ && data.get_ncols() == 0) {
-    Rf_warning("SQL statements must be issued with dbExecute() or dbSendStatement() instead of dbGetQuery() or dbSendQuery().");
+    Rf_warning("`dbGetQuery()`, `dbSendQuery()` and `dbFetch()` should only be used with `SELECT` queries. Did you mean `dbExecute()`, `dbSendStatement()` or `dbGetRowsAffected()`?");
   }
 
   while (!complete_) {

--- a/tests/testthat/test-dbSendQuery.R
+++ b/tests/testthat/test-dbSendQuery.R
@@ -45,7 +45,7 @@ test_that("simple position binding works", {
       ),
       "deprecated"
     ),
-    "SQL statements"
+    "`SELECT` queries"
   )
 
   expect_equal(dbReadTable(con, "t1")$x, c(1, 2))
@@ -64,7 +64,7 @@ test_that("simple named binding works", {
     bind.data = data.frame(y = 1, x = 2)
   ) %>%
     expect_warning("deprecated") %>%
-    expect_warning("SQL statements")
+    expect_warning("`SELECT` queries")
 
   expect_equal(dbReadTable(con, "t1")$x, c(1, 2))
 })

--- a/tests/testthat/test-dbSendQuery.R
+++ b/tests/testthat/test-dbSendQuery.R
@@ -173,3 +173,15 @@ test_that("mark UTF-8 encoding on non-ASCII colnames", {
   expect_equal(Encoding(got), "UTF-8")
   expect_equal(got, cn_field)
 })
+
+test_that("dbFetch with statement other than SELECT warns reasonably (#523)", {
+  memoise::forget(warning_once)
+  con <- dbConnect(SQLite(), ":memory:")
+  on.exit(dbDisconnect(con), add = TRUE)
+
+  dbWriteTable(con, "t1", data.frame(x = 1, y = 2))
+  res <- dbSendStatement(con, "INSERT INTO t1 VALUES (2, 1)")
+  on.exit(dbClearResult(res), add = TRUE, after = FALSE)
+
+  expect_warning(dbFetch(res), "dbGetRowsAffected")
+})


### PR DESCRIPTION
Fixes #523.