### PR TITLE
fledge: CRAN release v2.3.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 2.3.7.9901
+Version: 2.3.8
 Date: 2024-11-17
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,15 +9,12 @@
 ## Features
 
 - Upgrade bundled SQLite to 3.47.0 (#525).
+
 - Add uuid extension (@rfhb, #517).
 
 ## Documentation
 
 - Reword warning message for misuse of `dbGetQuery()`/`dbSendQuery()`/`dbFetch()` (#524, @mikmart).
-
-## Uncategorized
-
-- Only internal changes.
 
 
 # RSQLite 2.3.7 (2024-05-26)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 2.3.7.9901 (2024-11-17)
-
-- Only internal changes.
-
-
-# RSQLite 2.3.7.9900 (2024-11-17)
+# RSQLite 2.3.8 (2024-11-17)
 
 ## Bug fixes
 
@@ -14,12 +9,15 @@
 ## Features
 
 - Upgrade bundled SQLite to 3.47.0 (#525).
-
 - Add uuid extension (@rfhb, #517).
 
 ## Documentation
 
 - Reword warning message for misuse of `dbGetQuery()`/`dbSendQuery()`/`dbFetch()` (#524, @mikmart).
+
+## Uncategorized
+
+- Only internal changes.
 
 
 # RSQLite 2.3.7 (2024-05-26)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RSQLite 2.3.7.9900
+RSQLite 2.3.8
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-17, problems found: https://cran.r-project.org/web/checks/check_results_RSQLite.html
- [ ] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-windows-x86_64
     Found the following Rd file(s) with Rd \link{} targets missing package
     anchors:
     SQLite.Rd: dbConnect
     SQLiteConnection-class.Rd: DBIConnection-class
     SQLiteDriver-class.Rd: dbConnect, DBIDriver-class, dbUnloadDriver
     SQLiteResult-class.Rd: dbSendQuery, dbSendStatement, DBIResult-class
     keywords-dep.Rd: dbQuoteIdentifier
     query-dep.Rd: dbSendQuery, dbGetQuery, dbBind
     Please provide package anchors for all Rd \link{} targets not in the
     package itself and the base packages.

Check results at: https://cran.r-project.org/web/checks/check_results_RSQLite.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`