### PR TITLE
fledge: CRAN pre-release v2.3.8.9900

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -1,0 +1,100 @@
+# R-hub's generic GitHub Actions workflow file. It's canonical location is at
+# https://github.com/r-hub/actions/blob/v1/workflows/rhub.yaml
+# You can update this file to a newer version using the rhub2 package:
+#
+# rhub::rhub_setup()
+#
+# It is unlikely that you need to modify this file manually.
+
+name: R-hub
+run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
+
+on:
+  push:
+    branches:
+      - "cran-*"
+  workflow_dispatch:
+    inputs:
+      config:
+        description: 'A comma separated list of R-hub platforms to use.'
+        type: string
+        default: 'linux,windows,macos'
+      name:
+        description: 'Run name. You can leave this empty now.'
+        type: string
+      id:
+        description: 'Unique ID. You can leave this empty now.'
+        type: string
+
+jobs:
+
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      containers: ${{ steps.rhub-setup.outputs.containers }}
+      platforms: ${{ steps.rhub-setup.outputs.platforms }}
+
+    steps:
+    # NO NEED TO CHECKOUT HERE
+    - uses: r-lib/actions/setup-r@v2
+
+    - uses: r-hub/actions/setup@v1
+      with:
+        config: ${{ github.event.inputs.config }}
+      id: rhub-setup
+
+  linux-containers:
+    needs: setup
+    if: ${{ needs.setup.outputs.containers != '[]' }}
+    runs-on: ubuntu-latest
+    name: ${{ matrix.config.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.setup.outputs.containers) }}
+    container:
+      image: ${{ matrix.config.container }}
+
+    steps:
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/run-check@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+
+  other-platforms:
+    needs: setup
+    if: ${{ needs.setup.outputs.platforms != '[]' }}
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.setup.outputs.platforms) }}
+
+    steps:
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/setup-r@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/run-check@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RSQLite
 Title: SQLite Interface for R
-Version: 2.3.8.9007
+Version: 2.3.8.9900
 Date: 2024-11-30
 Authors@R: c(
     person("Kirill", "Müller", , "kirill@cynkra.com", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,26 +6,6 @@
 
 - Upgrade bundled SQLite to 3.47.1 (#550).
 
-## Continuous integration
-
-- Import from actions-sync, check carefully (#545).
-
-- Import from actions-sync, check carefully (#543).
-
-- Import from actions-sync, check carefully (#540).
-
-- Import from actions-sync, check carefully (#538).
-
-- Import from actions-sync, check carefully (#537).
-
-- Import from actions-sync, check carefully (#536).
-
-- Import from actions-sync, check carefully (#532).
-
-## Uncategorized
-
-- Internal changes only.
-
 
 # RSQLite 2.3.8 (2024-11-17)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,11 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# RSQLite 2.3.8.9007 (2024-11-30)
+# RSQLite 2.3.8.9900 (2024-11-30)
 
 ## Features
 
 - Upgrade bundled SQLite to 3.47.1 (#550).
 
-
-# RSQLite 2.3.8.9006 (2024-11-30)
-
 ## Continuous integration
 
 - Import from actions-sync, check carefully (#545).
@@ -25,91 +22,7 @@
 
 - Import from actions-sync, check carefully (#532).
 
-
-# RSQLite 2.3.8.9005 (2024-11-29)
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#545).
-
-- Import from actions-sync, check carefully (#543).
-
-- Import from actions-sync, check carefully (#540).
-
-- Import from actions-sync, check carefully (#538).
-
-- Import from actions-sync, check carefully (#537).
-
-- Import from actions-sync, check carefully (#536).
-
-- Import from actions-sync, check carefully (#532).
-
-
-# RSQLite 2.3.8.9004 (2024-11-28)
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#545).
-
-- Import from actions-sync, check carefully (#543).
-
-- Import from actions-sync, check carefully (#540).
-
-- Import from actions-sync, check carefully (#538).
-
-- Import from actions-sync, check carefully (#537).
-
-- Import from actions-sync, check carefully (#536).
-
-- Import from actions-sync, check carefully (#532).
-
-
-# RSQLite 2.3.8.9003 (2024-11-27)
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#543).
-
-- Import from actions-sync, check carefully (#540).
-
-- Import from actions-sync, check carefully (#538).
-
-- Import from actions-sync, check carefully (#537).
-
-- Import from actions-sync, check carefully (#536).
-
-- Import from actions-sync, check carefully (#532).
-
-
-# RSQLite 2.3.8.9002 (2024-11-26)
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#540).
-
-- Import from actions-sync, check carefully (#538).
-
-- Import from actions-sync, check carefully (#537).
-
-- Import from actions-sync, check carefully (#536).
-
-- Import from actions-sync, check carefully (#532).
-
-
-# RSQLite 2.3.8.9001 (2024-11-25)
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#538).
-
-- Import from actions-sync, check carefully (#537).
-
-- Import from actions-sync, check carefully (#536).
-
-- Import from actions-sync, check carefully (#532).
-
-
-# RSQLite 2.3.8.9000 (2024-11-17)
+## Uncategorized
 
 - Internal changes only.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-RSQLite 2.3.8
+RSQLite 2.3.8.9900
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-30, problems found: https://cran.r-project.org/web/checks/check_results_RSQLite.html
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/RSQLite.out>

Check results at: https://cran.r-project.org/web/checks/check_results_RSQLite.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`